### PR TITLE
Added a "VOD available" flag

### DIFF
--- a/src/main/xsd/export/content.xsd
+++ b/src/main/xsd/export/content.xsd
@@ -91,6 +91,11 @@ targetNamespace="http://video-metadata.tv4.se/content/v1" version="1.0">
           <xs:documentation>List of externalReference (of what?)</xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element name="vodAvailable" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+        <xs:annotation>
+          <xs:documentation>Flag to indicate that there is a VOD media available for the content.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="additionalProperties" type="common:propertyListType" minOccurs="0" />
     </xs:sequence>
   </xs:complexType>


### PR DESCRIPTION
We (the EMP project) would like to add this flag to the content part of the export in order to indicate that there is a VOD media available for an asset. This is needed for a working catchup flow integration between TV4 and EMP. Please find attached a description of a scenario where it would be used.

[EMP_TV4_catchup_import_export.pdf](https://github.com/TV4/video-metadata-api/files/163127/EMP_TV4_catchup_import_export.pdf)
